### PR TITLE
Add version for atf/optee/uboot

### DIFF
--- a/meta-freescale-3rdparty-mbl/recipes-bsp/atf/atf-imx7-mbl_git.inc
+++ b/meta-freescale-3rdparty-mbl/recipes-bsp/atf/atf-imx7-mbl_git.inc
@@ -4,13 +4,13 @@
 
 DEPENDS += "u-boot-tools-native"
 
-# MBL_ATF_VERSION should be updated to match version pointed to by SRCREV
-MBL_ATF_VERSION ?= "2.0"
-SRCREV_atf = "6a80c8bbc961ab55a562e0030247419e363286f7"
-
 inherit mbl-artifact-names
 
 require recipes-bsp/atf/atf.inc
+
+# MBL_ATF_VERSION should be updated to match version pointed to by SRCREV
+MBL_ATF_VERSION = "2.0"
+SRCREV_atf = "6a80c8bbc961ab55a562e0030247419e363286f7"
 
 # We do not compile bl2 and fip.bin here, because we can speicify two raw images in wks file.
 MBL_UNIFIED_BIN = "bl2.bin.imx"

--- a/meta-freescale-3rdparty-mbl/recipes-bsp/atf/atf-imx7-mbl_git.inc
+++ b/meta-freescale-3rdparty-mbl/recipes-bsp/atf/atf-imx7-mbl_git.inc
@@ -4,6 +4,8 @@
 
 DEPENDS += "u-boot-tools-native"
 
+# MBL_ATF_VERSION should be updated to match version pointed to by SRCREV
+MBL_ATF_VERSION ?= "2.0"
 SRCREV_atf = "6a80c8bbc961ab55a562e0030247419e363286f7"
 
 inherit mbl-artifact-names

--- a/meta-freescale-mbl/recipes-bsp/atf/atf-imx8mmevk-mbl_git.bb
+++ b/meta-freescale-mbl/recipes-bsp/atf/atf-imx8mmevk-mbl_git.bb
@@ -7,7 +7,10 @@ DEPENDS += "u-boot-tools-native"
 
 require recipes-bsp/atf/atf.inc
 
+# MBL_ATF_VERSION should be updated to match version pointed to by SRCREV
+MBL_ATF_VERSION = "1.5"
 SRCREV_atf = "ba3f2f0002ca1277307b96d975b980f9b55d470c"
+
 LIC_FILES_CHKSUM_remove = "file://license.rst;md5=c709b197e22b81ede21109dbffd5f363"
 LIC_FILES_CHKSUM_append = "file://license.rst;md5=3b83ef96387f14655fc854ddc3c6bd57"
 

--- a/meta-freescale-mbl/recipes-bsp/u-boot/u-boot-fslc_%.bbappend
+++ b/meta-freescale-mbl/recipes-bsp/u-boot/u-boot-fslc_%.bbappend
@@ -2,6 +2,9 @@
 #
 # SPDX-License-Identifier: MIT
 
+# MBL_UBOOT_VERSION should be updated to match version pointed to by SRCREV
+MBL_UBOOT_VERSION = "2018.11-rc1"
+
 SRCREV = "c0c4ee5fce01ec0818c4f27ce029d9b16c8849ad"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"

--- a/meta-freescale-mbl/recipes-bsp/u-boot/u-boot-imx_%.bbappend
+++ b/meta-freescale-mbl/recipes-bsp/u-boot/u-boot-imx_%.bbappend
@@ -7,6 +7,9 @@ SRC_URI = "git://git.linaro.org/landing-teams/working/mbl/u-boot.git;protocol=ht
 	   file://0001-arm-imx-Add-mbl-specific-boot-option.patch \
 "
 
+# MBL_UBOOT_VERSION should be updated to match version pointed to by SRCREV
+MBL_UBOOT_VERSION="2018.03"
+
 SRCREV = "336522718c23e6adb1fe206fc0beab4465d5ecda"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/u-boot-imx:"

--- a/meta-freescale-mbl/recipes-bsp/u-boot/u-boot-imx_%.bbappend
+++ b/meta-freescale-mbl/recipes-bsp/u-boot/u-boot-imx_%.bbappend
@@ -8,7 +8,7 @@ SRC_URI = "git://git.linaro.org/landing-teams/working/mbl/u-boot.git;protocol=ht
 "
 
 # MBL_UBOOT_VERSION should be updated to match version pointed to by SRCREV
-MBL_UBOOT_VERSION="2018.03"
+MBL_UBOOT_VERSION = "2018.03"
 
 SRCREV = "336522718c23e6adb1fe206fc0beab4465d5ecda"
 

--- a/meta-linaro-mbl/meta-optee/recipes-security/optee/optee-os_%.bbappend
+++ b/meta-linaro-mbl/meta-optee/recipes-security/optee/optee-os_%.bbappend
@@ -7,6 +7,10 @@ DEPENDS_append_raspberrypi3-mbl = " arm-aarch64-toolchain-native "
 
 LICENSE = "BSD-2-Clause"
 
+# MBL_OPTEE_VERSION should be updated to match version pointed to by SRCREV
+MBL_OPTEE_VERSION = "3.4.0"
+MBL_OPTEE_VERSION_imx8mmevk-mbl = "3.2.0"
+
 SRCREV="2976273f390e0654fb95928838ed0e251be8451f"
 SRCREV_imx8mmevk-mbl = "230e2d697800dcb7070e924577c7a6069c866477"
 SRC_URI="git://git.linaro.org/landing-teams/working/mbl/optee_os.git;protocol=https;nobranch=1 \

--- a/meta-raspberrypi-mbl/recipes-bsp/atf/atf-raspberrypi3-mbl_git.bb
+++ b/meta-raspberrypi-mbl/recipes-bsp/atf/atf-raspberrypi3-mbl_git.bb
@@ -15,7 +15,7 @@ require recipes-bsp/atf/atf.inc
 DEPENDS += "arm-aarch64-toolchain-native"
 
 # MBL_ATF_VERSION should be updated to match version pointed to by SRCREV
-MBL_ATF_VERSION ?= "2.0"
+MBL_ATF_VERSION = "2.0"
 SRCREV_atf = "c48d02bade88b07fa7f43aa44e5217f68e5d047f"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/atf-raspberrypi3-mbl:"

--- a/meta-raspberrypi-mbl/recipes-bsp/atf/atf-raspberrypi3-mbl_git.bb
+++ b/meta-raspberrypi-mbl/recipes-bsp/atf/atf-raspberrypi3-mbl_git.bb
@@ -14,6 +14,8 @@ require recipes-bsp/atf/atf.inc
 #   and incorporated into the firmware.
 DEPENDS += "arm-aarch64-toolchain-native"
 
+# MBL_ATF_VERSION should be updated to match version pointed to by SRCREV
+MBL_ATF_VERSION ?= "2.0"
 SRCREV_atf = "c48d02bade88b07fa7f43aa44e5217f68e5d047f"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/atf-raspberrypi3-mbl:"


### PR DESCRIPTION
Add version string for atf/optee/uboot so that the version can
be checked explicitly.

Signed-off-by: Jun Nie <jun.nie@linaro.org>